### PR TITLE
Fix culture-sensitive `ToLower` in `XRLayoutBuilder`

### DIFF
--- a/Bugsmash/Bugsmash.csproj
+++ b/Bugsmash/Bugsmash.csproj
@@ -18,6 +18,7 @@
     <Reference Include="DataModels" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll" Publicize="true" />
     <Reference Include="IPA.Loader" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll" />
     <Reference Include="Main" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll" Publicize="true" />
+    <Reference Include="Unity.InputSystem" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.InputSystem.dll" Publicize="true" />
     <Reference Include="UnityEngine" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll" />
     <Reference Include="UnityEngine.CoreModule" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll" />
 

--- a/Bugsmash/HarmonyPatches/XRLayoutBuilder.cs
+++ b/Bugsmash/HarmonyPatches/XRLayoutBuilder.cs
@@ -1,0 +1,24 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine.InputSystem.XR;
+
+namespace Bugsmash.HarmonyPatches
+{
+    [HarmonyPatch(typeof(XRLayoutBuilder), nameof(XRLayoutBuilder.Build))]
+    internal class XRLayoutBuilderBuild
+    {
+        private static readonly MethodInfo _stringToLowerMethod = AccessTools.DeclaredMethod(typeof(string), nameof(string.ToLower), Array.Empty<Type>());
+        private static readonly MethodInfo _stringToLowerInvariantMethod = AccessTools.DeclaredMethod(typeof(string), nameof(string.ToLowerInvariant));
+
+        protected static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return new CodeMatcher(instructions)
+                .MatchForward(false, new CodeMatch(i => i.Calls(_stringToLowerMethod)))
+                .ThrowIfInvalid($"string.ToLower() not found")
+                .SetOperandAndAdvance(_stringToLowerInvariantMethod)
+                .InstructionEnumeration();
+        }
+    }
+}


### PR DESCRIPTION
`XRLayoutBuilder.Build` uses `ToLower` instead of `ToLowerInvariant` which causes the `isTracked` control on `TrackedDevice` to not work properly when the system language is set to Turkish.

Looking at the Input Debugger in a dummy Unity project, it's not mapping the controls properly (`ıstracked` instead of `istracked`):
![istracked](https://github.com/user-attachments/assets/d46e22d1-00f0-4036-b9d7-5f1c7054f159)

Bug report submitted to Unity, but for now this fixes the issue.